### PR TITLE
SCRD-6919 Address layout problems with smaller screens

### DIFF
--- a/themes/suse/_styles.scss
+++ b/themes/suse/_styles.scss
@@ -113,3 +113,10 @@ button.close {
     background-color: $btn-danger-hover-bg;
   }
 }
+
+// Prevent pagination controls from overwriting pulldown menu
+#sidebar {
+  @media (max-width: $screen-xs-max) {
+      z-index: 4;
+  }
+}

--- a/themes/suse/_styles.scss
+++ b/themes/suse/_styles.scss
@@ -4,99 +4,66 @@
 @import "./_variables.scss";
 
 
-.navbar-brand > img {
- display: inline-block;
- height: 36px;
- vertical-align: bottom;
- margin-left: -4px;
-}
 .navbar-brand {
   &.suse, &.suse:hover {
     background: $blue-darker;
-    padding-right: 0px;
-    width: 220px;
+  }
+  .openstack-logo {
+    width: 200px;
   }
 }
 
-.openstack-logo {
-  width: 200px;
-}
 
 body {
   background: $body-bg;
 }
 
-.topbar .navbar	{
-  border: none;
-
-  .container-fluid {
-    padding-left: 0px;
-  }
-  .navbar-header {
-    border-bottom: 1px solid #003258;
-    padding-left: 15px;
-  }
-}
-
-#main_content {
-  padding-top: 36px;
-}
-
 #sidebar {
-  position: fixed;
-  top: 37px;
-  left: 0;
-  height: 100%;
+  height: 100vh;
   background: $blue-darker;
-  width: 220px;
-  overflow-y: auto;
+  .panel {
+    color: $body-bg;
+    background: $blue-darker;
+
+    > a {
+      color: $bc-white;
+      background: $blue-darker;
+
+      &:hover {
+        background: $blue-dark;
+      }
+    }
+
+    .list-group-item:not(.active) {
+      color: #fff;
+      background: $blue-dark;
+    }
+
+    a:not(.active):hover {
+      color: #fff;
+      background: $blue-less-dark;
+    }
+  }
 }
 
-#sidebar-accordion {
-  width: 220px;
-}
 
 .breadcrumb {
-  background-color: #fff;
+  background-color: $body-bg;
 }
 
 #splash {
   background-color: $blue-darker;
-}
-#splash .panel, .panel-default > .logo-panel-heading, .panel-footer {
-  background-color: $blue-darker;
-  color: #ffffff;
-  border: 0;
-  margin-top: 5em;
-}
-#splash input {
-  color: #ffffff;
-  background-color: $blue-dark;
-  border-color: #001727;
-}
-
-#sidebar .panel {
-    color: #fff;
-    background: $blue-darker;
-}
-
-#sidebar .panel > a {
-    color: #fff;
-    background: $blue-darker;
-}
-
-#sidebar .panel > a:hover {
-    color: #fff;
-    background: $blue-dark;
-}
-
-#sidebar .panel .list-group-item:not(.active) {
-      color: #fff;
-      background: $blue-dark;
-}
-#sidebar .panel a:not(.active):hover {
-      color: #fff;
-      background: $blue-less-dark;
+  .panel, .panel-default > .logo-panel-heading, .panel-footer {
+    background-color: $blue-darker;
+    color: #ffffff;
+    border: 0;
+    margin-top: 5em;
+  }
+  input {
+    color: #ffffff;
+    background-color: $blue-dark;
+    border-color: #001727;
+  }
 }
 
 button.close {

--- a/themes/suse/_styles.scss
+++ b/themes/suse/_styles.scss
@@ -19,7 +19,7 @@ body {
 }
 
 #sidebar {
-  height: 10000vh;
+  height: 100vh;
   background: $blue-darker;
   .panel {
     color: $body-bg;

--- a/themes/suse/_styles.scss
+++ b/themes/suse/_styles.scss
@@ -19,7 +19,7 @@ body {
 }
 
 #sidebar {
-  height: 100vh;
+  height: 10000vh;
   background: $blue-darker;
   .panel {
     color: $body-bg;

--- a/themes/suse/_styles.scss
+++ b/themes/suse/_styles.scss
@@ -15,7 +15,14 @@
 
 
 body {
-  background: $body-bg;
+  // Paint the entire page background with the same color as the navbar background
+  // so that no moatter how the user scrolls down, it will still appear to have
+  // a navbar.  Then paint the background of the portion of the content body on the
+  // right with the desired background color.
+  background: $blue-darker;
+    #content_body > .container-fluid {
+      background: $body-bg;
+  }
 }
 
 #sidebar {

--- a/themes/suse/_styles.scss
+++ b/themes/suse/_styles.scss
@@ -16,12 +16,14 @@
 
 body {
   // Paint the entire page background with the same color as the navbar background
-  // so that no moatter how the user scrolls down, it will still appear to have
+  // so that no matter how far the user scrolls down, it will still appear to have
   // a navbar.  Then paint the background of the portion of the content body on the
   // right with the desired background color.
-  background: $blue-darker;
-    #content_body > .container-fluid {
-      background: $body-bg;
+  #main_content {
+    background: $blue-darker;
+  }
+  #content_body > .container-fluid {
+    background: $body-bg;
   }
 }
 

--- a/themes/suse/_variables.scss
+++ b/themes/suse/_variables.scss
@@ -392,13 +392,13 @@ $navbar-default-link-disabled-bg:          transparent !default;
 
 // Navbar brand label
 $navbar-default-brand-color:               $navbar-default-link-color !default;
-$navbar-default-brand-hover-color:         darken($navbar-default-brand-color, 10%) !default;
+$navbar-default-brand-hover-color:         $gray-dark;
 $navbar-default-brand-hover-bg:            transparent !default;
 
 // Navbar toggle
-$navbar-default-toggle-hover-bg:           #00243e !default;
+$navbar-default-toggle-hover-bg:           $gray-dark !default;
 $navbar-default-toggle-icon-bar-bg:        $bc-gray-100 !default;
-$navbar-default-toggle-border-color:       #003159 !default;
+$navbar-default-toggle-border-color:       $gray-dark !default;
 
 
 // Inverted navbar


### PR DESCRIPTION
The styling attempted to visually merge the top title bar with the areas
below it (the left nav bar and the main content window), and to force
the left navbar to be drawn when it otherwise would not be. This caused
a number problems when viewing on a modest sized screen (1024 width) or
when resizing.

Removed some of the custom nav bar forced styling and let the
underlying styles of horizon and bootstrap correctly hide and show
the navbar when appropriate.  Also collapsed some of the repetitive
css into more friendly scss nested styles.