### PR TITLE
Remove whitespace on top of login page (SCRD-7142)

### DIFF
--- a/themes/suse/_styles.scss
+++ b/themes/suse/_styles.scss
@@ -13,6 +13,11 @@
   }
 }
 
+.container.login.suse-login {
+  margin-top: 0px;
+  padding-top: $navbar-height * 2;
+}
+
 
 body {
   // Paint the entire page background with the same color as the navbar background

--- a/themes/suse/templates/auth/_login_page.html
+++ b/themes/suse/templates/auth/_login_page.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block pre_login %}
-  <div class="container login">
+  <div class="container login suse-login">
     <div class="row">
       <div class="col-xs-12 col-sm-12 col-md-10 col-lg-8 horizontal-center">
         {{ block.super }}


### PR DESCRIPTION
Replace margin-top with padding-top to avoid the html element being
visible above the container on the login page