### PR TITLE
Use primary active color for btn-group selection (SCRD-8650)

### DIFF
--- a/themes/suse/_styles.scss
+++ b/themes/suse/_styles.scss
@@ -205,6 +205,14 @@ button.close {
   }
 }
 
+.btn-group {
+  > .btn.btn-default.active {
+    color: $btn-primary-active-color;
+    background-color: $btn-primary-active-bg;
+    border-color: $btn-primary-active-border;
+  }
+}
+
 // Prevent pagination controls from overwriting pulldown menu
 #sidebar {
   @media (max-width: $screen-xs-max) {


### PR DESCRIPTION
Active buttons in button groups comprised of default buttons are
difficult to identify. The selection is only signified by a slight
shadow. Change to use the primary, active, green color for easy
identification.