### PR TITLE
Remove links to end user & admin user guides

### DIFF
--- a/dashboards/help/guides/templates/guides/index.html
+++ b/dashboards/help/guides/templates/guides/index.html
@@ -10,14 +10,6 @@
 
 {% block main %}
 <ul style="list-style-type:disc; margin-left:20px">
-   <li>
-        <a href="{% static "help/user/suse-openstack-cloud-upstream-user.en.html" %}">OpenStack End User Guide</a>
-        (<a href="{% static "help/user/suse-openstack-cloud-upstream-user.en.pdf" %}">PDF</a>)
-    </li>
-    <li>
-        <a href="{% static "help/admin/suse-openstack-cloud-upstream-admin.en.html" %}">OpenStack Admin User Guide</a>
-        (<a href="{% static "help/admin/suse-openstack-cloud-upstream-admin.en.pdf" %}">PDF</a>)
-    </li>
     <li>
         <a href="{% static "help/supplement/suse-openstack-cloud-supplement.en.html" %}">Supplement to Admin User Guide and End User Guide</a>
         (<a href="{% static "help/supplement/suse-openstack-cloud-supplement.en.pdf" %}">PDF</a>)


### PR DESCRIPTION
We dropped these in Cloud 9.

Note: we probably need to create a pike branch before merging this.