### PR TITLE
[pike] SCRD-7984 fixed help links (bsc#1156531)

### DIFF
--- a/dashboards/help/guides/templates/guides/index.html
+++ b/dashboards/help/guides/templates/guides/index.html
@@ -10,17 +10,17 @@
 
 {% block main %}
 <ul style="list-style-type:disc; margin-left:20px">
-    <li>
-        <a href="{% static "help/user/" %}">OpenStack End User Guide</a>
-        (<a href="{% static "help/suse-openstack-cloud-upstream-user_en.pdf" %}">PDF</a>)
+   <li>
+        <a href="{% static "help/user/suse-openstack-cloud-upstream-user.en.html" %}">OpenStack End User Guide</a>
+        (<a href="{% static "help/user/suse-openstack-cloud-upstream-user.en.pdf" %}">PDF</a>)
     </li>
     <li>
-        <a href="{% static "help/admin/" %}">OpenStack Admin User Guide</a>
-        (<a href="{% static "help/suse-openstack-cloud-upstream-admin_en.pdf" %}">PDF</a>)
+        <a href="{% static "help/admin/suse-openstack-cloud-upstream-admin.en.html" %}">OpenStack Admin User Guide</a>
+        (<a href="{% static "help/admin/suse-openstack-cloud-upstream-admin.en.pdf" %}">PDF</a>)
     </li>
     <li>
-        <a href="{% static "help/supplement/" %}">Supplement to Admin User Guide and End User Guide</a>
-        (<a href="{% static "help/suse-openstack-cloud-supplement_en.pdf" %}">PDF</a>)
+        <a href="{% static "help/supplement/suse-openstack-cloud-supplement.en.html" %}">Supplement to Admin User Guide and End User Guide</a>
+        (<a href="{% static "help/supplement/suse-openstack-cloud-supplement.en.pdf" %}">PDF</a>)
     </li>
 </ul>
 </p>


### PR DESCRIPTION
(cherry picked from commit 650574bd31c65401e155a703a6f4fa28a760d505)

Backport of https://github.com/SUSE/openstack-dashboard-theme-SUSE/pull/13

The links are already different in SOC8 (pike) so we need the fix there as well. 

Kudos to @Itxaka for identifying the problem!